### PR TITLE
Adding the new URLs at the bottom for clarity

### DIFF
--- a/create_a_new_site.md
+++ b/create_a_new_site.md
@@ -55,7 +55,12 @@ drud file get {sitename}/{environment}-{sitename}-{timestamp}
 drud file get drud-{sitename}/{environment}-{sitename}-{timestamp}
 
 # Example
-drud file get drud-d7/production-d7-1493783396.tar.gz
+drud file get drud-anewsite/production-anewsite-1493783396.tar.gz
 ```
 
 The new jobs are at `https://leroy.drud.com/job/production-{sitename}` and `https://leroy.drud.com/job/staging-{sitename}`.
+
+The new site URLs are at:
+
+- https://{sitename}.drud.io
+- https://{sitename}prod.drud.io


### PR DESCRIPTION
## The Problem
The drud.io URLs were not specified with the rest of the digest information at the bottom of the document.

## The Fix
Added the DRUD URLs. Also changed the sitename for clarity.