### PR TITLE
Add reminder to remove users from tweetdeck

### DIFF
--- a/employee_exit_checklist.md
+++ b/employee_exit_checklist.md
@@ -15,4 +15,4 @@
 * rotate github tokens for service accounts (newmediadenverbot, etc.)
 * Revoke access to any lastpass secrets that are shared. Most should be invalidated instead. This is done in lastpass "sharing center".
 * Make sure user is removed from [circle team](https://circleci.com/team). 
-
+* Make sure user is removed from Tweetdeck for the drud account (if they have access)


### PR DESCRIPTION
## The Problem:
Not that we have a shared twitter account we need to make sure people are properly removed